### PR TITLE
Fix tests with AbstractSlice and SliceInstance

### DIFF
--- a/grails-app/domain/be/cytomine/image/AbstractSlice.groovy
+++ b/grails-app/domain/be/cytomine/image/AbstractSlice.groovy
@@ -73,7 +73,7 @@ class AbstractSlice extends CytomineDomain implements Serializable {
     void checkAlreadyExist() {
         withNewSession {
             AbstractSlice slice = AbstractSlice.findByImageAndChannelAndZStackAndTime(image, channel, zStack, time)
-            if (slice?.id != id)
+            if (slice != null && (slice?.id != id))
                 throw new AlreadyExistException("AbstractSlice (C:${channel}, Z:${zStack}, T:${time}) already exists for AbstractImage ${image?.id}")
         }
     }

--- a/grails-app/domain/be/cytomine/image/SliceInstance.groovy
+++ b/grails-app/domain/be/cytomine/image/SliceInstance.groovy
@@ -51,7 +51,7 @@ class SliceInstance extends CytomineDomain implements Serializable {
     void checkAlreadyExist() {
         withNewSession {
             SliceInstance slice = SliceInstance.findByImageAndBaseSlice(image, baseSlice)
-            if (slice?.id != id)
+            if (slice != null && (slice?.id != id))
                 throw new AlreadyExistException("SliceInstance (C:${baseSlice?.channel}, Z:${baseSlice?.zStack}, T:${baseSlice?.time}) already exists for ImageInstance ${image?.id}")
         }
     }

--- a/src/groovy/be/cytomine/test/BasicInstanceBuilder.groovy
+++ b/src/groovy/be/cytomine/test/BasicInstanceBuilder.groovy
@@ -886,7 +886,7 @@ class BasicInstanceBuilder {
     static AbstractImage getAbstractImage() {
         AbstractImage image = AbstractImage.findByOriginalFilename("originalFilename")
         if (!image) {
-            image = new AbstractImage(uploadedFile: getUploadedFile(), originalFilename:"originalFilename", width: 16000, height: 16000, depth: 5, duration: 2, channels: 3)
+            image = new AbstractImage(uploadedFile: getUploadedFile(), originalFilename:"originalFilename", width: 16000, height: 16000, depth: 1, duration: 1, channels: 1)
         }
         image = saveDomain(image)
         //saveDomain(new StorageAbstractImage(storage : getStorage(), abstractImage : image))
@@ -919,7 +919,7 @@ class BasicInstanceBuilder {
     }
 
     static AbstractImage getAbstractImageNotExist(String filename, boolean save = false) {
-        def image = new AbstractImage(uploadedFile: getUploadedFileNotExist(true), originalFilename:filename, width: 16000, height: 16000, depth: 5, duration: 2, channels: 3)
+        def image = new AbstractImage(uploadedFile: getUploadedFileNotExist(true), originalFilename:filename, width: 16000, height: 16000, depth: 1, duration: 1, channels: 1)
         if(save) {
             saveDomain(image)
             saveDomain(new AbstractSlice(uploadedFile: image.uploadedFile, image: image, mime: getMime(),  channel: 0, zStack: 0, time: 0))
@@ -930,7 +930,7 @@ class BasicInstanceBuilder {
     }
 
     static AbstractImage getAbstractImageNotExist(UploadedFile uploadedFile, boolean save = false) {
-        def image = new AbstractImage(uploadedFile: uploadedFile, originalFilename:getRandomString(), width: 16000, height: 16000, depth: 5, duration: 2, channels: 3)
+        def image = new AbstractImage(uploadedFile: uploadedFile, originalFilename:getRandomString(), width: 16000, height: 16000, depth: 1, duration: 1, channels: 1)
         if(save) {
             saveDomain(image)
             //saveDomain(new StorageAbstractImage(storage : getStorage(), abstractImage : image))
@@ -1860,6 +1860,9 @@ class BasicInstanceBuilder {
             abstractImage.originalFilename = "test.tif"
             abstractImage.width = 25088
             abstractImage.height = 37888
+            abstractImage.channels = 1
+            abstractImage.depth = 1
+            abstractImage.duration = 1
             abstractImage.magnification = 8
             abstractImage.physicalSizeX = 0.65d
             abstractImage.originalFilename = "test01.jpg"

--- a/test/functional/be/cytomine/AnnotationActionTests.groovy
+++ b/test/functional/be/cytomine/AnnotationActionTests.groovy
@@ -34,9 +34,8 @@ class AnnotationActionTests {
     }
 
     void testListByImage() {
-        def slice = SliceInstanceAPI.buildBasicSlice(Infos.SUPERADMINLOGIN, Infos.SUPERADMINPASSWORD)
-        def annotation = BasicInstanceBuilder.getUserAnnotationNotExist(slice, true)
-        def image = slice.image
+        def image = BasicInstanceBuilder.getImageInstance()
+        def annotation = BasicInstanceBuilder.getUserAnnotationNotExist(image.referenceSlice, true)
         def json = JSON.parse("{image:${image.id}, annotationIdent:${annotation.id}, action:Test}")
 
         def result = AnnotationActionAPI.create(json.toString(),Infos.SUPERADMINLOGIN, Infos.SUPERADMINPASSWORD)
@@ -58,9 +57,9 @@ class AnnotationActionTests {
     }
 
     void testListBySlice() {
-        def slice = SliceInstanceAPI.buildBasicSlice(Infos.SUPERADMINLOGIN, Infos.SUPERADMINPASSWORD)
+        def image = BasicInstanceBuilder.getImageInstance()
+        def slice = image.referenceSlice
         def annotation = BasicInstanceBuilder.getUserAnnotationNotExist(slice, true)
-        def image = slice.image
         def json = JSON.parse("{slice:${slice.id}, annotationIdent:${annotation.id}, action:Test}")
 
         def result = AnnotationActionAPI.create(json.toString(),Infos.SUPERADMINLOGIN, Infos.SUPERADMINPASSWORD)

--- a/test/functional/be/cytomine/security/ProjectSecurityTests.groovy
+++ b/test/functional/be/cytomine/security/ProjectSecurityTests.groovy
@@ -1558,10 +1558,9 @@ class ProjectSecurityTests extends SecurityTestsAbstract {
 
         /*admin data*/
         //Create an annotation (by admin)
-        ImageInstance imageAdmin = BasicInstanceBuilder.getImageInstanceNotExist(project,false)
+        ImageInstance imageAdmin = BasicInstanceBuilder.getImageInstanceNotExist(project,true)
         imageAdmin.user = admin;
         BasicInstanceBuilder.saveDomain(imageAdmin)
-        slice = BasicInstanceBuilder.getSliceInstanceNotExist(imageAdmin,true)
         UserAnnotation annotationAdmin = BasicInstanceBuilder.getUserAnnotationNotExist(project,imageAdmin,admin,false)
         annotationAdmin.user = admin;
         BasicInstanceBuilder.saveDomain(annotationAdmin)
@@ -1583,10 +1582,9 @@ class ProjectSecurityTests extends SecurityTestsAbstract {
 
         /*simple user data*/
         //Create an annotation (by user)
-        ImageInstance imageUser = BasicInstanceBuilder.getImageInstanceNotExist(project,false)
+        ImageInstance imageUser = BasicInstanceBuilder.getImageInstanceNotExist(project,true)
         imageUser.user = simpleUser;
         BasicInstanceBuilder.saveDomain(imageUser)
-        slice = BasicInstanceBuilder.getSliceInstanceNotExist(imageUser,true)
         UserAnnotation annotationUser = BasicInstanceBuilder.getUserAnnotationNotExist(project,imageUser,simpleUser,false)
         annotationUser.user = simpleUser;
         BasicInstanceBuilder.saveDomain(annotationUser)


### PR DESCRIPTION
Fix issues in `checkAlreadyExists` for AbstractSlice and SliceInstance introduced by 11a231ebacf386323f684330d647c5c2a9e0308f

Fix tests for AbstractSlice and SliceInstance which are exploiting something that should not be possible: slice C/Z/T indexes should be continuous and lower than image's channels/depth/duration respectively. Optimization introduced by 26c711e2858f06694e03f4cf41682973055cd271 suppose that, such as e.g. webUI, PIMS, ...  (We should prevent the possibility to create out of bound slices.)

