### PR TITLE
Fix vulnerability CVE-2022-41923

### DIFF
--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -20,6 +20,7 @@ import be.cytomine.spring.CustomAjaxAwareAuthenticationEntryPoint
 import be.cytomine.spring.CustomDefaultRedirectStrategy
 import be.cytomine.spring.CustomSavedRequestAwareAuthenticationSuccessHandler
 import be.cytomine.web.CytomineMultipartHttpServletRequest
+import be.cytomine.PatchedInterceptUrlMapFilterInvocationDefinition
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.web.authentication.AjaxAwareAuthenticationSuccessHandler
 import grails.util.Holders
@@ -92,5 +93,12 @@ beans = {
     currentRoleServiceProxy(org.springframework.aop.scope.ScopedProxyFactoryBean) {
         targetBeanName = 'currentRoleService'
         proxyTargetClass = true
+    }
+
+    def conf = SpringSecurityUtils.securityConfig
+    objectDefinitionSource(be.cytomine.PatchedInterceptUrlMapFilterInvocationDefinition) {
+        if (conf.rejectIfNoRule instanceof Boolean) {
+            rejectIfNoRule = conf.rejectIfNoRule
+        }
     }
 }

--- a/src/groovy/be/cytomine/PatchedInterceptUrlMapFilterInvocationDefinition.groovy
+++ b/src/groovy/be/cytomine/PatchedInterceptUrlMapFilterInvocationDefinition.groovy
@@ -1,0 +1,26 @@
+package be.cytomine
+
+import grails.plugin.springsecurity.web.access.intercept.InterceptUrlMapFilterInvocationDefinition
+import org.springframework.web.util.UrlPathHelper
+
+import javax.servlet.http.HttpServletRequest
+
+class PatchedInterceptUrlMapFilterInvocationDefinition extends InterceptUrlMapFilterInvocationDefinition {
+
+    private static final UrlPathHelper urlPathHelper = new UrlPathHelper()
+
+    @Override
+    protected String calculateUri(HttpServletRequest request) {
+        String requestUri = urlPathHelper.getRequestUri(request)
+        stripContextPath(requestUri, request)
+    }
+
+    protected String stripContextPath(String uri, HttpServletRequest request) {
+        String contextPath = request.contextPath
+        if (contextPath && uri.startsWith(contextPath)) {
+            uri = uri.substring(contextPath.length())
+        }
+        uri
+    }
+
+}


### PR DESCRIPTION
I fixed the security vulnerability related to CVE-2022-41923 in the Grails Spring Security Core plugin by following the workaround method provided in
 https://github.com/grails/grails-spring-security-core/security/advisories/GHSA-frqg-vvxg-jqqh